### PR TITLE
Implement event tracker in rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,0 +1,69 @@
+on: [push, pull_request]
+
+name: Rust
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @vinted/boost

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "event_tracker"
+version = "0.1.0"
+authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>"]
+edition = "2018"
+
+[dependencies]
+bytes = "1"
+futures-channel = "0.3"
+futures-util = { version = "0.3", features = ["sink"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tokio = { version = "1", default-features = false, features = ["rt", "time"] }
+tokio-util = { version = "0.6", features = ["codec", "net"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# event-tracker-rs
-Rust port of https://github.com/vinted/event-tracker
+# Event Tracker
+
+A Rust port of [vinted/event-tracker](https://github.com/vinted/event-tracker)
+
+## Installation
+
+Add this line to your application's `Cargo.toml`:
+
+```toml
+event_tracker = { git = "https://github.com/vinted/event-tracker-rs" }
+```
+
+## Usage
+
+Configure the crate in your application executable, e.g. `src/main.rs` or `src/bin/executable_name.rs`.
+
+```rust
+let addr = "0.0.0.0:5005".parse().expect("valid addr");
+let udp_relay = event_tracker::relay::Udp::new(addr);
+let _ = event_tracker::set_relay(udp_relay);
+```
+
+In your library code, create an event structure and use it for tracking
+
+```rust
+#[derive(Debug, Serialize)]
+struct SearchEvent {
+    total: i32,
+    timed_out: bool,
+    query: String,
+}
+
+let search_event = SearchEvent {
+    total: 123,
+    timed_out: false,
+    query: "shoes".to_string(),
+};
+
+let event = event_tracker::Event::new("event", "FR", search_event);
+
+let _ = event_tracker::track(event);
+```
+
+Tracker implementations
+
+```rust
+event_tracker::relay::Noop
+event_tracker::relay::Udp
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.3'
+services:
+  udp-listener:
+    ports:
+      - '0.0.0.0:5005:5005'
+      - '0.0.0.0:5005:5005/udp'
+    container_name: udp-listener
+    image: mendhak/udp-listener

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -1,0 +1,26 @@
+use event_tracker::*;
+use serde::Serialize;
+
+#[tokio::main]
+async fn main() {
+    let addr = "0.0.0.0:5005".parse().expect("valid addr");
+
+    let udp_relay = Udp::new(addr);
+
+    let _ = set_relay(udp_relay);
+
+    track_events(1_000)
+}
+
+fn track_events(iterations: i32) {
+    #[derive(Debug, Serialize)]
+    struct SearchEvent {
+        iteration: i32,
+    }
+
+    for iteration in 1..iterations {
+        let event = Event::new("event", "FR", SearchEvent { iteration });
+
+        let _ = track(event);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+/// Crate level error enum
+#[derive(Debug)]
+pub enum Error {
+    /// Occurs when a relay has already been initialized
+    RelayAlreadyInitialized,
+
+    /// Occurs when an event cannot be serialized
+    Serde(serde_json::Error),
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RelayAlreadyInitialized => write!(
+                f,
+                "attempted to set relay after the relay was already initialized"
+            ),
+            Self::Serde(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Serde(error)
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+use std::{fmt::Debug, time::SystemTime};
+
+/// Event to track
+#[derive(Debug, Serialize)]
+pub struct Event<T>
+where
+    T: Debug + Serialize,
+{
+    /// Event name
+    pub event: &'static str,
+
+    /// Portal it's happening in
+    pub portal: String,
+
+    /// Current time in milliseconds since unix epoch
+    pub time: u128,
+
+    /// Additional tracking data
+    #[serde(flatten)]
+    pub tracking_data: T,
+}
+
+impl<T> Event<T>
+where
+    T: Debug + Serialize,
+{
+    /// Creates an instance of [`Event`]
+    pub fn new(event: &'static str, portal: impl Into<String>, tracking_data: T) -> Self {
+        Self {
+            event,
+            portal: portal.into(),
+            time: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("SystemTime before UNIX_EPOCH")
+                .as_millis(),
+            tracking_data,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,176 @@
+//! A Rust port of <https://github.com/vinted/event-tracker>
+//!
+//! In your application executable:
+//! ```
+//! use event_tracker::*;
+//! use serde::Serialize;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let addr = "0.0.0.0:5005".parse().expect("valid addr");
+//!
+//!     let udp_relay = Udp::new(addr);
+//!
+//!     let _ = set_relay(udp_relay);
+//!
+//!     track_events(1_000)
+//! }
+//!
+//! fn track_events(iterations: i32) {
+//!     #[derive(Debug, Serialize)]
+//!     struct SearchEvent {
+//!         iteration: i32,
+//!     }
+//!
+//!     for iteration in 1..iterations {
+//!         let event = Event::new("event", "FR", SearchEvent { iteration });
+//!
+//!         let _ = track(event);
+//!     }
+//! }
+//! ```
+//! In your library code, create an event structure and use it for tracking
+//! ```
+//! # use event_tracker::*;
+//! # use event_tracker::relay::*;
+//! # use serde::Serialize;
+//! #[derive(Debug, Serialize)]
+//! struct SearchEvent {
+//!     total: i32,
+//!     timed_out: bool,
+//!     query: String,
+//! }
+//!
+//! let search_event = SearchEvent {
+//!     total: 123,
+//!     timed_out: false,
+//!     query: "shoes".to_string(),
+//! };
+//!
+//! let event = Event::new("event", "FR", search_event);
+//!
+//! let _ = event_tracker::track(event);
+//! ```
+#![deny(
+    warnings,
+    bad_style,
+    const_err,
+    dead_code,
+    improper_ctypes,
+    non_shorthand_field_patterns,
+    no_mangle_generic_items,
+    overflowing_literals,
+    path_statements,
+    patterns_in_fns_without_body,
+    private_in_public,
+    unconditional_recursion,
+    unused,
+    unused_allocation,
+    unused_comparisons,
+    unused_parens,
+    while_true,
+    missing_debug_implementations,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results,
+    trivial_numeric_casts,
+    unreachable_pub,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results,
+    deprecated,
+    unconditional_recursion,
+    unknown_lints,
+    unreachable_code,
+    unused_mut
+)]
+
+#[macro_use]
+extern crate tracing;
+
+mod error;
+mod event;
+pub mod relay;
+
+pub use self::error::*;
+pub use self::event::*;
+pub use self::relay::*;
+
+use std::{
+    hint::spin_loop,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+static mut RELAY: &dyn Relay = &Noop;
+static STATE: AtomicUsize = AtomicUsize::new(0);
+
+const UNINITIALIZED: usize = 0;
+const INITIALIZING: usize = 1;
+const INITIALIZED: usize = 2;
+
+/// Result type alias with consistent error type
+type Result<T> = std::result::Result<T, Error>;
+
+fn set_relay_inner<F>(make_relay: F) -> Result<()>
+where
+    F: FnOnce() -> &'static dyn Relay,
+{
+    let old_state = match STATE.compare_exchange(
+        UNINITIALIZED,
+        INITIALIZING,
+        Ordering::SeqCst,
+        Ordering::SeqCst,
+    ) {
+        Ok(s) | Err(s) => s,
+    };
+    match old_state {
+        UNINITIALIZED => {
+            unsafe {
+                RELAY = make_relay();
+            }
+            STATE.store(INITIALIZED, Ordering::SeqCst);
+            Ok(())
+        }
+        INITIALIZING => {
+            while STATE.load(Ordering::SeqCst) == INITIALIZING {
+                spin_loop();
+            }
+            Err(Error::RelayAlreadyInitialized)
+        }
+        _ => Err(Error::RelayAlreadyInitialized),
+    }
+}
+
+fn relay() -> &'static dyn Relay {
+    if STATE.load(Ordering::SeqCst) != INITIALIZED {
+        static NOP: Noop = Noop;
+        &NOP
+    } else {
+        unsafe { RELAY }
+    }
+}
+
+/// Initializes [`Relay`] for the whole application
+pub fn set_relay<T: 'static + Relay>(relay: T) -> Result<()> {
+    set_relay_inner(|| Box::leak(Box::new(relay)))
+}
+
+/// Tracks the actual event
+pub fn track<T>(event: Event<T>) -> Result<()>
+where
+    T: std::fmt::Debug + serde::Serialize,
+{
+    match serde_json::to_vec(&event) {
+        Ok(buf) => relay().transport(bytes::Bytes::from(buf)),
+        Err(error) => {
+            error!(error=%error, "Couldn't serialize event");
+
+            Err(error.into())
+        }
+    }
+}

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,0 +1,16 @@
+//! [`Relay`] is an abstraction on where events will be sent to
+
+mod noop;
+mod udp;
+
+pub use self::noop::*;
+pub use self::udp::*;
+
+/// Trait for event transportation
+pub trait Relay {
+    /// Accepts serialized event as bytes that should be sent to a certain protocol, such as:
+    /// - HTTP
+    /// - TCP
+    /// - UDP
+    fn transport(&self, event: bytes::Bytes) -> crate::Result<()>;
+}

--- a/src/relay/noop.rs
+++ b/src/relay/noop.rs
@@ -1,0 +1,20 @@
+use super::Relay;
+
+/// A [`Relay`] that will print events to standard output
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Noop;
+
+impl Noop {
+    /// Creates an instance of [`Noop`] [`Relay`]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Relay for Noop {
+    fn transport(&self, event: bytes::Bytes) -> crate::Result<()> {
+        println!("event: {:?}", event);
+
+        Ok(())
+    }
+}

--- a/src/relay/udp.rs
+++ b/src/relay/udp.rs
@@ -1,0 +1,80 @@
+use super::Relay;
+use bytes::Bytes;
+use futures_channel::mpsc::{self, Receiver, Sender};
+use futures_util::{SinkExt, StreamExt};
+use std::net::SocketAddr;
+use tokio::{net::UdpSocket, time};
+use tokio_util::{codec::BytesCodec, udp::UdpFramed};
+
+const DEFAULT_BUFFER: usize = 512;
+const DEFAULT_TIMEOUT: u32 = 10_000;
+
+/// A [`Relay`] that will print events to UDP listener
+#[derive(Debug, Clone)]
+pub struct Udp {
+    sender: Sender<Bytes>,
+}
+
+impl Udp {
+    /// Creates an instance of [`Udp`] [`Relay`]
+    pub fn new(addr: SocketAddr) -> Self {
+        let (sender, receiver) = mpsc::channel::<Bytes>(DEFAULT_BUFFER);
+
+        background_task(addr, receiver);
+
+        Self { sender }
+    }
+}
+
+impl Relay for Udp {
+    fn transport(&self, event: Bytes) -> crate::Result<()> {
+        if let Err(ref error) = self.sender.clone().try_send(event) {
+            tracing::error!(error=%error, "Could not send bytes to UDP socket");
+        }
+
+        Ok(())
+    }
+}
+
+fn background_task(addr: SocketAddr, mut receiver: Receiver<Bytes>) {
+    let task = Box::pin(async move {
+        // Reconnection loop
+        loop {
+            handle_udp_connection(addr, &mut receiver).await;
+
+            // Sleep before re-attempting
+            time::sleep(time::Duration::from_millis(DEFAULT_TIMEOUT as u64)).await;
+        }
+    });
+
+    let _ = tokio::spawn(task);
+}
+
+async fn handle_udp_connection(addr: SocketAddr, receiver: &mut Receiver<Bytes>) {
+    let bind_addr = if addr.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    };
+
+    let udp_socket = match UdpSocket::bind(bind_addr).await {
+        Ok(ok) => ok,
+        Err(ref error) => {
+            tracing::error!(error=%error, "Could not bind to UDP socket");
+
+            return;
+        }
+    };
+
+    let udp_stream = UdpFramed::new(udp_socket, BytesCodec::new());
+
+    let (mut sink, _) = udp_stream.split();
+
+    while let Some(bytes) = receiver.next().await {
+        if let Err(ref error) = sink.send((bytes, addr)).await {
+            tracing::error!(error=%error, "Could not send data to UDP socket");
+
+            break;
+        };
+    }
+}


### PR DESCRIPTION
A rust port of https://github.com/vinted/event-tracker.

Have not ported HTTP relay because it was only used in DevTest environment. Might add it some time later.

cc @vinted/boost 