### PR TITLE
Add HTTP relay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 bytes = "1"
 futures-channel = "0.3"
 futures-util = { version = "0.3", features = ["sink"] }
+hyper = { version = "0.14", default-features = false, features = ["client", "http1", "runtime"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
@@ -15,4 +16,5 @@ tokio = { version = "1", default-features = false, features = ["rt", "time"] }
 tokio-util = { version = "0.6", features = ["codec", "net"] }
 
 [dev-dependencies]
+tracing-subscriber = "0.2"
 tokio = { version = "1", features = ["full"] }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.3'
+
 services:
   udp-listener:
     ports:
@@ -6,3 +7,12 @@ services:
       - '0.0.0.0:5005:5005/udp'
     container_name: udp-listener
     image: mendhak/udp-listener
+
+  http-listener:
+    image: mendhak/http-https-echo
+    environment:
+      - HTTP_PORT=8888
+      - HTTPS_PORT=9999
+    ports:
+      - '0.0.0.0:8888:8888'
+      - '0.0.0.0:9999:9999'

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -1,4 +1,6 @@
 use serde::Serialize;
+use std::time::Duration;
+use tokio::time::sleep;
 use tracing::Level;
 use vinted_event_tracker::*;
 
@@ -8,15 +10,18 @@ async fn main() {
         .with_max_level(Level::DEBUG)
         .finish();
 
-    let addr = "0.0.0.0:5005".parse().expect("valid addr");
+    let url = "http://0.0.0.0:8888".parse().expect("valid addr");
 
-    let udp_relay = Udp::new(addr);
+    let http_relay = Http::new(url);
 
-    if let Err(ref error) = set_relay(udp_relay) {
-        tracing::error!(%error, "Couldn't set UDP relay");
+    if let Err(ref error) = set_relay(http_relay) {
+        tracing::error!(%error, "Couldn't set HTTP relay");
     }
 
-    track_events(1_000)
+    track_events(1_000);
+
+    // Needed on standalone example to wait until all events have been sent
+    sleep(Duration::from_secs(10)).await;
 }
 
 fn track_events(iterations: i32) {

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,12 +1,9 @@
 use serde::Serialize;
 use std::{fmt::Debug, time::SystemTime};
 
-/// Event to track
+/// Event base
 #[derive(Debug, Serialize)]
-pub struct Event<T>
-where
-    T: Debug + Serialize,
-{
+pub struct EventBase {
     /// Event name
     pub event: &'static str,
 
@@ -15,6 +12,17 @@ where
 
     /// Current time in milliseconds since unix epoch
     pub time: u128,
+}
+
+/// Event to track
+#[derive(Debug, Serialize)]
+pub struct Event<T>
+where
+    T: Debug + Serialize,
+{
+    /// Event base
+    #[serde(flatten)]
+    pub base: EventBase,
 
     /// Additional tracking data
     #[serde(flatten)]
@@ -28,12 +36,14 @@ where
     /// Creates an instance of [`Event`]
     pub fn new(event: &'static str, portal: impl Into<String>, tracking_data: T) -> Self {
         Self {
-            event,
-            portal: portal.into(),
-            time: SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .expect("SystemTime before UNIX_EPOCH")
-                .as_millis(),
+            base: EventBase {
+                event,
+                portal: portal.into(),
+                time: SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .expect("SystemTime before UNIX_EPOCH")
+                    .as_millis(),
+            },
             tracking_data,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,9 +166,9 @@ where
     T: std::fmt::Debug + serde::Serialize,
 {
     match serde_json::to_vec(&event) {
-        Ok(buf) => relay().transport(bytes::Bytes::from(buf)),
+        Ok(buf) => relay().transport(event.base, bytes::Bytes::from(buf)),
         Err(error) => {
-            error!(error=%error, "Couldn't serialize event");
+            error!(%error, "Couldn't serialize event");
 
             Err(error.into())
         }

--- a/src/relay/http.rs
+++ b/src/relay/http.rs
@@ -1,0 +1,73 @@
+use super::Relay;
+use crate::EventBase;
+use bytes::Bytes;
+use futures_channel::mpsc::{self, Receiver, Sender};
+use futures_util::StreamExt;
+use hyper::{client::HttpConnector, header, Body, Client, Method, Request, Uri};
+
+const DEFAULT_BUFFER: usize = 512;
+
+/// A [`Relay`] that will print events to HTTP listener
+#[derive(Debug, Clone)]
+pub struct Http {
+    sender: Sender<HttpEvent>,
+}
+
+type HttpEvent = (EventBase, Bytes);
+
+impl Http {
+    /// Creates an instance of [`Http`] [`Relay`]
+    pub fn new(url: Uri) -> Self {
+        let (sender, mut receiver) = mpsc::channel::<HttpEvent>(DEFAULT_BUFFER);
+
+        let client = Client::new();
+
+        let task = Box::pin(async move {
+            handle_http_connection(&client, url, &mut receiver).await;
+        });
+
+        let _ = tokio::spawn(task);
+
+        Self { sender }
+    }
+}
+
+async fn handle_http_connection(
+    client: &Client<HttpConnector>,
+    url: Uri,
+    receiver: &mut Receiver<HttpEvent>,
+) {
+    while let Some((event_base, bytes)) = receiver.next().await {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(url.clone())
+            .header(header::CONTENT_TYPE, "application/json")
+            .header("X-Local-Time", event_base.time.to_string())
+            .body(Body::from(bytes));
+
+        match req {
+            Ok(req) => {
+                if let Err(ref error) = client.request(req).await {
+                    tracing::error!(%error, "Couldn't send data to HTTP relay");
+
+                    break;
+                }
+            }
+            Err(ref error) => {
+                tracing::error!(%error, "Couldn't send data to HTTP relay");
+
+                break;
+            }
+        }
+    }
+}
+
+impl Relay for Http {
+    fn transport(&self, event_base: EventBase, event: Bytes) -> crate::Result<()> {
+        if let Err(ref error) = self.sender.clone().try_send((event_base, event)) {
+            tracing::error!(%error, "Couldn't send data to HTTP relay");
+        }
+
+        Ok(())
+    }
+}

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,8 +1,10 @@
 //! [`Relay`] is an abstraction on where events will be sent to
 
+mod http;
 mod noop;
 mod udp;
 
+pub use self::http::*;
 pub use self::noop::*;
 pub use self::udp::*;
 
@@ -12,5 +14,5 @@ pub trait Relay {
     /// - HTTP
     /// - TCP
     /// - UDP
-    fn transport(&self, event: bytes::Bytes) -> crate::Result<()>;
+    fn transport(&self, event_base: crate::EventBase, event: bytes::Bytes) -> crate::Result<()>;
 }

--- a/src/relay/noop.rs
+++ b/src/relay/noop.rs
@@ -1,6 +1,7 @@
 use super::Relay;
+use crate::EventBase;
 
-/// A [`Relay`] that will print events to standard output
+/// A [`Relay`] that won't do anything with events
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Noop;
 
@@ -12,9 +13,7 @@ impl Noop {
 }
 
 impl Relay for Noop {
-    fn transport(&self, event: bytes::Bytes) -> crate::Result<()> {
-        println!("event: {:?}", event);
-
+    fn transport(&self, _event_base: EventBase, _event: bytes::Bytes) -> crate::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
This is needed for sandbox to be able to track events with debug pin.

- Adds HTTP relay, needed for the sandbox.
- Makes error messages more consistent
- Improves examples
- Adds EventBase structure, this is easier to transfer base data around if needed (HTTP relay needed to know the local time, that wouldn't be easily possible to obtain from the event, because it's already converted to Bytes)

cc @vinted/boost @justinakiud 