### PR TITLE
Revert "Check if sender is closed before sending an event"

### DIFF
--- a/src/relay/udp.rs
+++ b/src/relay/udp.rs
@@ -29,13 +29,7 @@ impl Udp {
 
 impl Relay for Udp {
     fn transport(&self, _event_base: EventBase, event: Bytes) -> crate::Result<()> {
-        let mut sender = self.sender.clone();
-
-        if sender.is_closed() {
-            return Ok(());
-        }
-
-        if let Err(ref error) = sender.try_send(event) {
+        if let Err(ref error) = self.sender.clone().try_send(event) {
             tracing::error!(%error, "Couldn't send data to UDP relay");
         }
 


### PR DESCRIPTION
Reverts vinted/event-tracker-rs#8

This needs a better fix, it's ugly and solves nothing.