### PR TITLE
Refactor event tracker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,11 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-futures-channel = "0.3"
-futures-util = { version = "0.3", features = ["sink"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tokio = { version = "1", default-features = false, features = ["rt", "time"] }
-tokio-util = { version = "0.6", features = ["codec", "net"] }
+tokio = { version = "1", default-features = false }
 
 [dev-dependencies]
 tracing-subscriber = "0.3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,17 @@
 version: '3.3'
 
 services:
-  udp-listener:
-    ports:
-      - '0.0.0.0:5005:5005'
-      - '0.0.0.0:5005:5005/udp'
-    container_name: udp-listener
+  my-udp-listener:
     image: mendhak/udp-listener
+    ports:
+      - 0.0.0.0:5005:5005
+      - 0.0.0.0:5005:5005/udp
 
-  http-listener:
+  my-http-listener:
     image: mendhak/http-https-echo
     environment:
       - HTTP_PORT=8888
       - HTTPS_PORT=9999
     ports:
-      - '0.0.0.0:8888:8888'
-      - '0.0.0.0:9999:9999'
+      - 0.0.0.0:8888:8888
+      - 0.0.0.0:9999:9999

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -7,7 +7,7 @@ async fn main() {
 
     let addr = "0.0.0.0:5005".parse().expect("valid addr");
 
-    let udp_relay = Udp::new(addr);
+    let udp_relay = Udp::bind(addr).await.expect("valid udp relay");
 
     if let Err(ref error) = set_relay(udp_relay) {
         tracing::error!(%error, "Couldn't set UDP relay");

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,13 @@ pub enum Error {
     RelayAlreadyInitialized,
 
     /// Occurs when an event cannot be serialized
-    Serde(serde_json::Error),
+    SerdeJson(serde_json::Error),
+
+    /// I/O error
+    Io(std::io::Error),
+
+    /// FromStr error
+    AddrParse(std::net::AddrParseError),
 }
 
 impl std::error::Error for Error {}
@@ -13,17 +19,30 @@ impl std::error::Error for Error {}
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::RelayAlreadyInitialized => write!(
-                f,
-                "attempted to set relay after the relay was already initialized"
-            ),
-            Self::Serde(e) => write!(f, "{}", e),
+            Self::RelayAlreadyInitialized => {
+                "attempted to set relay after the relay was already initialized".fmt(f)
+            }
+            Self::SerdeJson(e) => e.fmt(f),
+            Self::Io(e) => e.fmt(f),
+            Self::AddrParse(e) => e.fmt(f),
         }
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
-        Self::Serde(error)
+        Self::SerdeJson(error)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<std::net::AddrParseError> for Error {
+    fn from(error: std::net::AddrParseError) -> Self {
+        Self::AddrParse(error)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! async fn main() {
 //!     let addr = "0.0.0.0:5005".parse().expect("valid addr");
 //!
-//!     let udp_relay = Udp::new(addr);
+//!     let udp_relay = Udp::bind(addr).await.expect("valid udp relay");
 //!
 //!     let _ = set_relay(udp_relay);
 //!
@@ -113,10 +113,7 @@ const UNINITIALIZED: usize = 0;
 const INITIALIZING: usize = 1;
 const INITIALIZED: usize = 2;
 
-/// Result type alias with consistent error type
-type Result<T> = std::result::Result<T, Error>;
-
-fn set_relay_inner<F>(make_relay: F) -> Result<()>
+fn set_relay_inner<F>(make_relay: F) -> Result<(), Error>
 where
     F: FnOnce() -> &'static dyn Relay,
 {
@@ -156,12 +153,12 @@ fn relay() -> &'static dyn Relay {
 }
 
 /// Initializes [`Relay`] for the whole application
-pub fn set_relay<T: 'static + Relay>(relay: T) -> Result<()> {
+pub fn set_relay<T: 'static + Relay>(relay: T) -> Result<(), Error> {
     set_relay_inner(|| Box::leak(Box::new(relay)))
 }
 
 /// Tracks the actual event
-pub fn track<T>(event: Event<T>) -> Result<()>
+pub fn track<T>(event: Event<T>) -> Result<(), Error>
 where
     T: std::fmt::Debug + serde::Serialize,
 {

--- a/src/relay/http.rs
+++ b/src/relay/http.rs
@@ -1,41 +1,26 @@
-use super::Relay;
-use crate::EventBase;
+use crate::*;
 use bytes::Bytes;
-use futures_channel::mpsc::{self, Receiver, Sender};
-use futures_util::StreamExt;
 use reqwest::{header, Client, Url};
-
-const DEFAULT_BUFFER: usize = 512;
 
 /// A [`Relay`] that will print events to HTTP listener
 #[derive(Debug, Clone)]
 pub struct Http {
-    sender: Sender<HttpEvent>,
+    client: Client,
+    url: Url,
 }
-
-type HttpEvent = (EventBase, Bytes);
 
 impl Http {
     /// Creates an instance of [`Http`] [`Relay`]
     pub fn new(url: Url) -> Self {
-        let (sender, mut receiver) = mpsc::channel::<HttpEvent>(DEFAULT_BUFFER);
-
-        let client = Client::new();
-
-        let task = Box::pin(async move {
-            handle_http_connection(client, url, &mut receiver).await;
-        });
-
-        let _ = tokio::spawn(task);
-
-        Self { sender }
+        Self {
+            client: Client::new(),
+            url,
+        }
     }
-}
 
-async fn handle_http_connection(client: Client, url: Url, receiver: &mut Receiver<HttpEvent>) {
-    while let Some((event_base, bytes)) = receiver.next().await {
-        let mut req = client
-            .post(url.clone())
+    async fn send(client: Client, url: Url, event_base: EventBase, bytes: Bytes) {
+        let mut request = client
+            .post(url)
             .body(bytes)
             .header(header::CONTENT_TYPE, "application/json")
             .header("X-Local-Time", event_base.time.to_string())
@@ -43,41 +28,41 @@ async fn handle_http_connection(client: Client, url: Url, receiver: &mut Receive
             .header("X-Portal", event_base.portal);
 
         if let Some(debug_pin) = event_base.debug_pin {
-            req = req.header("X-Debug-Pin", debug_pin);
+            request = request.header("X-Debug-Pin", debug_pin);
         }
 
-        match req.send().await {
-            Ok(response) => {
-                let status = response.status();
-
-                if !status.is_success() {
-                    let status_code = status.as_u16();
-                    let response_body = response.text().await;
-
-                    match response_body {
-                        Ok(body) => {
-                            tracing::error!(%status_code, %body, "Couldn't complete HTTP request successfully");
-                        }
-                        Err(ref error) => {
-                            tracing::error!(%status_code, %error, "Couldn't complete HTTP request successfully");
-                        }
-                    }
-                }
-            }
-            Err(ref error) => {
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => {
                 tracing::error!(%error, "Couldn't send data to HTTP relay");
+                return;
+            }
+        };
 
-                break;
+        let status = response.status();
+
+        if !status.is_success() {
+            let status_code = status.as_u16();
+            let response_body = response.text().await;
+
+            match response_body {
+                Ok(body) => {
+                    tracing::error!(%status_code, %body, "Couldn't complete HTTP request successfully");
+                }
+                Err(error) => {
+                    tracing::error!(%status_code, %error, "Couldn't complete HTTP request successfully");
+                }
             }
         }
     }
 }
 
 impl Relay for Http {
-    fn transport(&self, event_base: EventBase, event: Bytes) -> crate::Result<()> {
-        if let Err(ref error) = self.sender.clone().try_send((event_base, event)) {
-            tracing::error!(%error, "Couldn't send data to HTTP relay");
-        }
+    fn transport(&self, event_base: EventBase, event: Bytes) -> Result<(), Error> {
+        let client = self.client.clone();
+        let url = self.url.clone();
+
+        let _ = tokio::spawn(Self::send(client, url, event_base, event));
 
         Ok(())
     }

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -7,6 +7,7 @@ mod udp;
 pub use self::http::*;
 pub use self::noop::*;
 pub use self::udp::*;
+use crate::Error;
 
 /// Trait for event transportation
 pub trait Relay {
@@ -14,5 +15,5 @@ pub trait Relay {
     /// - HTTP
     /// - TCP
     /// - UDP
-    fn transport(&self, event_base: crate::EventBase, event: bytes::Bytes) -> crate::Result<()>;
+    fn transport(&self, event_base: crate::EventBase, event: bytes::Bytes) -> Result<(), Error>;
 }

--- a/src/relay/noop.rs
+++ b/src/relay/noop.rs
@@ -1,5 +1,4 @@
-use super::Relay;
-use crate::EventBase;
+use crate::*;
 
 /// A [`Relay`] that won't do anything with events
 #[derive(Debug, Default, Clone, Copy)]
@@ -13,7 +12,7 @@ impl Noop {
 }
 
 impl Relay for Noop {
-    fn transport(&self, _event_base: EventBase, _event: bytes::Bytes) -> crate::Result<()> {
+    fn transport(&self, _event_base: EventBase, _event: bytes::Bytes) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/src/relay/udp.rs
+++ b/src/relay/udp.rs
@@ -1,81 +1,45 @@
-use super::Relay;
-use crate::EventBase;
+use crate::*;
 use bytes::Bytes;
-use futures_channel::mpsc::{self, Receiver, Sender};
-use futures_util::{SinkExt, StreamExt};
-use std::net::SocketAddr;
-use tokio::{net::UdpSocket, time};
-use tokio_util::{codec::BytesCodec, udp::UdpFramed};
-
-const DEFAULT_BUFFER: usize = 512;
-const DEFAULT_TIMEOUT: u32 = 10_000;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::net::UdpSocket;
 
 /// A [`Relay`] that will print events to UDP listener
 #[derive(Debug, Clone)]
 pub struct Udp {
-    sender: Sender<Bytes>,
+    udp_socket: Arc<UdpSocket>,
 }
 
 impl Udp {
-    /// Creates an instance of [`Udp`] [`Relay`]
-    pub fn new(addr: SocketAddr) -> Self {
-        let (sender, receiver) = mpsc::channel::<Bytes>(DEFAULT_BUFFER);
+    /// [Udp] relay will bind to the given remote_addr
+    pub async fn bind(remote_addr: SocketAddr) -> Result<Self, Error> {
+        let local_addr: SocketAddr = if remote_addr.is_ipv4() {
+            "0.0.0.0:0"
+        } else {
+            "[::]:0"
+        }
+        .parse()?;
 
-        background_task(addr, receiver);
+        let udp_socket = UdpSocket::bind(local_addr).await?;
 
-        Self { sender }
+        udp_socket.connect(&remote_addr).await?;
+
+        Ok(Self {
+            udp_socket: Arc::new(udp_socket),
+        })
+    }
+
+    async fn send(udp_socket: Arc<UdpSocket>, event: Bytes) {
+        if let Err(error) = udp_socket.send(&event).await {
+            tracing::error!(%error, "Couldn't send data to UDP relay");
+        }
     }
 }
 
 impl Relay for Udp {
-    fn transport(&self, _event_base: EventBase, event: Bytes) -> crate::Result<()> {
-        if let Err(ref error) = self.sender.clone().try_send(event) {
-            tracing::error!(%error, "Couldn't send data to UDP relay");
-        }
+    fn transport(&self, _event_base: EventBase, event: Bytes) -> Result<(), Error> {
+        let udp_socket = self.udp_socket.clone();
+        let _ = tokio::spawn(Self::send(udp_socket, event));
 
         Ok(())
-    }
-}
-
-fn background_task(addr: SocketAddr, mut receiver: Receiver<Bytes>) {
-    let task = Box::pin(async move {
-        // Reconnection loop
-        loop {
-            handle_udp_connection(addr, &mut receiver).await;
-
-            // Sleep before re-attempting
-            time::sleep(time::Duration::from_millis(DEFAULT_TIMEOUT as u64)).await;
-        }
-    });
-
-    let _ = tokio::spawn(task);
-}
-
-async fn handle_udp_connection(addr: SocketAddr, receiver: &mut Receiver<Bytes>) {
-    let bind_addr = if addr.is_ipv4() {
-        "0.0.0.0:0"
-    } else {
-        "[::]:0"
-    };
-
-    let udp_socket = match UdpSocket::bind(bind_addr).await {
-        Ok(ok) => ok,
-        Err(ref error) => {
-            tracing::error!(%error, "Couldn't bind to UDP socket");
-
-            return;
-        }
-    };
-
-    let udp_stream = UdpFramed::new(udp_socket, BytesCodec::new());
-
-    let (mut sink, _) = udp_stream.split();
-
-    while let Some(bytes) = receiver.next().await {
-        if let Err(ref error) = sink.send((bytes, addr)).await {
-            tracing::error!(%error, "Couldn't send data to UDP relay");
-
-            break;
-        };
     }
 }


### PR DESCRIPTION
Instead of building an internal UDP Server, we really need only a UDP Client, so that's what this refactoring is about - I've also simplified HTTP relay to get rid of channels - we don't need them either.

cc @ernestas-vinted 