### PR TITLE
Accept ToSocketAddrs implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ use vinted_event_tracker::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let remote_addr = "0.0.0.0:5005".parse()?;
-    let udp_relay = Udp::bind(remote_addr).await?;
+    let udp_relay = Udp::bind("0.0.0.0:5005").await?;
 
     set_relay(udp_relay)?;
 

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -5,9 +5,7 @@ use vinted_event_tracker::*;
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let addr = "0.0.0.0:5005".parse().expect("valid addr");
-
-    let udp_relay = Udp::bind(addr).await.expect("valid udp relay");
+    let udp_relay = Udp::bind("0.0.0.0:5005").await.expect("valid udp relay");
 
     if let Err(ref error) = set_relay(udp_relay) {
         tracing::error!(%error, "Couldn't set UDP relay");

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
 
     /// FromStr error
     AddrParse(std::net::AddrParseError),
+
+    /// FromStr error
+    NoRemoteAddr,
 }
 
 impl std::error::Error for Error {}
@@ -25,6 +28,7 @@ impl std::fmt::Display for Error {
             Self::SerdeJson(e) => e.fmt(f),
             Self::Io(e) => e.fmt(f),
             Self::AddrParse(e) => e.fmt(f),
+            Self::NoRemoteAddr => "no remote address specified".fmt(f),
         }
     }
 }


### PR DESCRIPTION
Instead of blindly accepting a SocketAddr, accept anything that implements `ToSocketAddrs`, this is a better practice and will allow specifying URL directly.
