### PR TITLE
Spaw only a single task for event tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 tokio = { version = "1", default-features = false }
+futures-channel = "0.3"
+futures-util = "0.3"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"


### PR DESCRIPTION
Instead of spawning a task for each event, this uses a channel that listens on a dedicated task for incoming events, this should be more efficient.