### PR TITLE
Simplify event tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,10 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
-tokio = { version = "1", default-features = false }
-futures-channel = "0.3"
-futures-util = "0.3"
 
 [dev-dependencies]
 tracing-subscriber = "0.3"
-tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Configure the crate in your application executable, e.g. `src/main.rs` or `src/b
 use serde::Serialize;
 use vinted_event_tracker::*;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let udp_relay = Udp::bind("0.0.0.0:5005")?;
 
     set_relay(udp_relay)?;

--- a/examples/http.rs
+++ b/examples/http.rs
@@ -1,10 +1,7 @@
 use serde::Serialize;
-use std::time::Duration;
-use tokio::time::sleep;
 use vinted_event_tracker::*;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     tracing_subscriber::fmt::init();
 
     let url = "https://0.0.0.0:9999".parse().expect("valid url");
@@ -16,9 +13,6 @@ async fn main() {
     }
 
     track_events(5);
-
-    // Needed on standalone example to wait until all events have been sent
-    sleep(Duration::from_secs(10)).await;
 }
 
 fn track_events(iterations: i32) {

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -1,8 +1,7 @@
 use serde::Serialize;
 use vinted_event_tracker::*;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     tracing_subscriber::fmt::init();
 
     let udp_relay = Udp::bind("0.0.0.0:5005").expect("valid udp relay");

--- a/src/relay/udp.rs
+++ b/src/relay/udp.rs
@@ -1,19 +1,11 @@
 use crate::{Error, EventBase, Relay};
 use bytes::Bytes;
-use futures_channel::mpsc::{self, Receiver, Sender};
-use futures_util::StreamExt;
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 
-/// UDP request timeout
-pub const DEFAULT_TIMEOUT: u32 = 10_000;
-
-/// Default UDP socket mpsc channel buffer
-pub const DEFAULT_BUFFER: usize = 10_000;
-
 /// A [`Relay`] that will print events to UDP listener
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Udp {
-    sender: Sender<Bytes>,
+    udp_socket: UdpSocket,
 }
 
 impl Udp {
@@ -36,33 +28,15 @@ impl Udp {
 
         udp_socket.connect(&remote_addr)?;
 
-        let (sender, receiver) = mpsc::channel(DEFAULT_BUFFER);
-
-        Self::background_task(udp_socket, receiver);
-
-        Ok(Self { sender })
-    }
-
-    fn background_task(udp_socket: UdpSocket, mut receiver: Receiver<Bytes>) {
-        let _ = tokio::spawn(Box::pin(async move {
-            Self::send(udp_socket, &mut receiver).await;
-        }));
-    }
-
-    async fn send(udp_socket: UdpSocket, receiver: &mut Receiver<Bytes>) {
-        while let Some(bytes) = receiver.next().await {
-            if let Err(ref error) = udp_socket.send(&bytes) {
-                tracing::error!(%error, "Couldn't send data to UDP relay");
-            };
-        }
+        Ok(Self { udp_socket })
     }
 }
 
 impl Relay for Udp {
     fn transport(&self, _event_base: EventBase, event: Bytes) -> Result<(), Error> {
-        if let Err(ref error) = self.sender.clone().try_send(event) {
-            tracing::error!(%error, "Couldn't send data to UDP relay");
-        }
+        if let Err(ref error) = self.udp_socket.send(&event) {
+            tracing::error!(%error, "Couldn't send data to UDP socket");
+        };
 
         Ok(())
     }


### PR DESCRIPTION
Removes the async part - we don't really need async for HTTP tracking, it's done in development only.

Removing channels for UDP socket - we can straight to the UDP listener.