### PR TITLE
Simplify relays

### DIFF
--- a/examples/http.rs
+++ b/examples/http.rs
@@ -23,7 +23,7 @@ fn track_events(iterations: i32) {
     }
 
     for iteration in 1..iterations {
-        let event = Event::new("system.test", "fr", 1234, SearchEvent { iteration });
+        let event = Event::new("system.test", "fr", Some(1234), SearchEvent { iteration });
 
         if let Err(ref error) = track(event) {
             tracing::error!(%error, "Couldn't track an event");

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -20,7 +20,7 @@ fn track_events(iterations: i32) {
     }
 
     for iteration in 1..iterations {
-        let event = Event::new("event", "portal", 1234, SearchEvent { iteration });
+        let event = Event::new("event", "portal", Some(1234), SearchEvent { iteration });
 
         if let Err(ref error) = track(event) {
             tracing::error!(%error, "Couldn't track an event");

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,7 +8,7 @@ pub struct EventBase {
     pub event: &'static str,
 
     /// Portal it's happening in
-    pub portal: String,
+    pub portal: &'static str,
 
     /// Current time in milliseconds since unix epoch
     pub time: u128,
@@ -39,19 +39,19 @@ where
     /// Creates an instance of [`Event`]
     pub fn new(
         event: &'static str,
-        portal: impl Into<String>,
-        debug_pin: impl Into<Option<i32>>,
+        portal: &'static str,
+        debug_pin: Option<i32>,
         tracking_data: T,
     ) -> Self {
         Self {
             base: EventBase {
                 event,
-                portal: portal.into(),
+                portal,
                 time: SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
                     .expect("SystemTime before UNIX_EPOCH")
                     .as_millis(),
-                debug_pin: debug_pin.into(),
+                debug_pin,
             },
             tracking_data,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,9 +39,6 @@
     clippy::wildcard_imports
 )]
 
-#[macro_use]
-extern crate tracing;
-
 mod error;
 mod event;
 pub mod relay;
@@ -111,12 +108,7 @@ pub fn track<T>(event: Event<T>) -> Result<(), Error>
 where
     T: std::fmt::Debug + serde::Serialize,
 {
-    match serde_json::to_vec(&event) {
-        Ok(buf) => relay().transport(event.base, bytes::Bytes::from(buf)),
-        Err(error) => {
-            error!(%error, "Couldn't serialize event");
+    let bytes = serde_json::to_vec(&event).map(Into::into)?;
 
-            Err(error.into())
-        }
-    }
+    relay().transport(event.base, bytes)
 }

--- a/src/relay/udp.rs
+++ b/src/relay/udp.rs
@@ -33,10 +33,8 @@ impl Udp {
 }
 
 impl Relay for Udp {
-    fn transport(&self, _event_base: EventBase, event: Bytes) -> Result<(), Error> {
-        if let Err(ref error) = self.udp_socket.send(&event) {
-            tracing::error!(%error, "Couldn't send data to UDP socket");
-        };
+    fn transport(&self, _: EventBase, event: Bytes) -> Result<(), Error> {
+        let _ = self.udp_socket.send(&event)?;
 
         Ok(())
     }


### PR DESCRIPTION
There's no point in a generic constructor for this one, we can use exact types just fine.