### PR TITLE
Cleanup UDP relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use vinted_event_tracker::*;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let udp_relay = Udp::bind("0.0.0.0:5005").await?;
+    let udp_relay = Udp::new("0.0.0.0:5005").await?;
 
     set_relay(udp_relay)?;
 

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -5,7 +5,7 @@ use vinted_event_tracker::*;
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let udp_relay = Udp::bind("0.0.0.0:5005").await.expect("valid udp relay");
+    let udp_relay = Udp::new("0.0.0.0:5005").await.expect("valid udp relay");
 
     if let Err(ref error) = set_relay(udp_relay) {
         tracing::error!(%error, "Couldn't set UDP relay");

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,15 +3,6 @@
 pub enum Error {
     /// Occurs when an event cannot be serialized
     SerdeJson(serde_json::Error),
-
-    /// I/O error
-    Io(std::io::Error),
-
-    /// FromStr error
-    AddrParse(std::net::AddrParseError),
-
-    /// FromStr error
-    NoRemoteAddr,
 }
 
 impl std::error::Error for Error {}
@@ -20,9 +11,6 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SerdeJson(e) => e.fmt(f),
-            Self::Io(e) => e.fmt(f),
-            Self::AddrParse(e) => e.fmt(f),
-            Self::NoRemoteAddr => "no remote address specified".fmt(f),
         }
     }
 }
@@ -30,17 +18,5 @@ impl std::fmt::Display for Error {
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Self::SerdeJson(error)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(error: std::io::Error) -> Self {
-        Self::Io(error)
-    }
-}
-
-impl From<std::net::AddrParseError> for Error {
-    fn from(error: std::net::AddrParseError) -> Self {
-        Self::AddrParse(error)
     }
 }

--- a/src/relay/udp.rs
+++ b/src/relay/udp.rs
@@ -1,5 +1,6 @@
-use crate::{Error, EventBase, Relay};
+use crate::{EventBase, Relay};
 use std::{
+    io,
     net::{SocketAddr, ToSocketAddrs},
     sync::Arc,
 };
@@ -13,19 +14,19 @@ pub struct Udp {
 
 impl Udp {
     /// [Udp] relay will bind to the given remote_addr
-    pub async fn bind<S>(remote_addrs: S) -> Result<Self, Error>
+    pub async fn new<S>(remote_addrs: S) -> Result<Self, io::Error>
     where
         S: ToSocketAddrs,
     {
         let mut remote_addrs = remote_addrs.to_socket_addrs()?;
-        let remote_addr = remote_addrs.next().ok_or(Error::NoRemoteAddr)?;
+        let remote_addr = remote_addrs
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "no remote address found"))?;
 
-        let local_addr: SocketAddr = if remote_addr.is_ipv4() {
-            "0.0.0.0:0"
-        } else {
-            "[::]:0"
-        }
-        .parse()?;
+        let local_addr = match remote_addr.is_ipv4() {
+            true => Self::local_addr_v4(),
+            false => Self::local_addr_v6(),
+        };
 
         let udp_socket = UdpSocket::bind(local_addr).await?;
 
@@ -35,6 +36,14 @@ impl Udp {
             udp_socket: Arc::new(udp_socket),
         })
     }
+
+    fn local_addr_v4() -> SocketAddr {
+        "0.0.0.0:0".parse().unwrap()
+    }
+
+    fn local_addr_v6() -> SocketAddr {
+        "[::]:0".parse().unwrap()
+    }
 }
 
 impl Relay for Udp {
@@ -42,5 +51,16 @@ impl Relay for Udp {
         let udp_socket = self.udp_socket.clone();
 
         let _ = tokio::spawn(async move { udp_socket.send(&event).await });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_local_addr_correctly() {
+        let _ = Udp::local_addr_v4();
+        let _ = Udp::local_addr_v6();
     }
 }


### PR DESCRIPTION
Uses io error, removes redundant error propagation because I assign local host addresses manually and test that upfront.