### PR TITLE
Fix/make it compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ fn track_search_event() {
     track(event, portal, debug_pin, search_event);
 }
 ```
+
+## Local spin
+To run UDP example:
+1. Listen for events:
+```
+nc -kul 5005
+```
+2. In separate session, run example:
+```
+cargo run --package vinted_event_tracker --example udp 
+```
+3. See captured events, like:
+```
+...{"event":"event","portal":"portal","time":1708000488315,"debug_pin":1234,"iteration":945}...
+```
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(
     warnings,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,
@@ -10,7 +9,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,


### PR DESCRIPTION
* FIx these:
```
   Compiling vinted_event_tracker v0.1.0 (/Users/marius/vinted/event-tracker-rs)
error: lint `const_err` has been removed: converted into hard error, see issue #71800 <https://github.com/rust-lang/rust/issues/71800> for more information
 --> src/lib.rs:5:5
  |
5 |     const_err,
  |     ^^^^^^^^^
  |
note: the lint level is defined here
 --> src/lib.rs:3:5
  |
3 |     warnings,
  |     ^^^^^^^^
  = note: `#[deny(renamed_and_removed_lints)]` implied by `#[deny(warnings)]`

error: lint `private_in_public` has been removed: replaced with another group of lints, see RFC <https://rust-lang.github.io/rfcs/2145-type-privacy.html> for more information
  --> src/lib.rs:13:5
   |
13 |     private_in_public,
   |     ^^^^^^^^^^^^^^^^^

error: could not compile `vinted_event_tracker` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `vinted_event_tracker` (lib test) due to 2 previous errors
```

* Add info how to run local example for common folks