### PR TITLE
Add deprecation notice for UDP/REST/JSON endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Tracking Events Pipeline has been refined and improved.
 
 As part of this update, the **UDP/REST/JSON endpoint has been deprecated** and is no longer the recommended integration method for producing tracking events. Please migrate to the **gRPC endpoint**, which provides better performance, stronger contracts, and improved reliability.
 
-To simplify the migration, a new Go library has been created that provides native support for producing tracking events via gRPC:
+To simplify the migration, a new Rust library has been created that provides native support for producing tracking events via gRPC:
 
 https://github.com/vinted/rs-tracking-events-producer
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# :warning: Deprecation Notice: UDP/REST/JSON Tracking Events Endpoint
+
+The Tracking Events Pipeline has been refined and improved.
+
+As part of this update, the **UDP/REST/JSON endpoint has been deprecated** and is no longer the recommended integration method for producing tracking events. Please migrate to the **gRPC endpoint**, which provides better performance, stronger contracts, and improved reliability.
+
+To simplify the migration, a new Go library has been created that provides native support for producing tracking events via gRPC:
+
+https://github.com/vinted/rs-tracking-events-producer
+
+Future enhancements and support will be focused on the gRPC-based implementation.
+
 # Event Tracker
 
 An abstraction for event tracking


### PR DESCRIPTION
Added deprecation notice for UDP/REST/JSON endpoint and recommended migration to gRPC.